### PR TITLE
Set property.Type to the appropriate enum

### DIFF
--- a/SktCaptureHelper.m
+++ b/SktCaptureHelper.m
@@ -1231,7 +1231,7 @@
 -(void)getDataFormatWithCompletionHandler:(void(^)(SKTResult result, SKTCaptureDataFormat dataFormat)) block {
     SKTCaptureProperty* property = [SKTCaptureProperty new];
     property.ID = SKTCapturePropertyIDDataFormatDevice;
-    property.Type = SKTCaptureDeviceTypeNone;
+    property.Type = SKTCapturePropertyTypeNone;
     [self getProperty:property completionHandler:^(SKTResult result, SKTCaptureProperty *complete) {
         if(block != nil) {
             SKTCaptureDataFormat format = SKTCaptureDataFormatPacket;


### PR DESCRIPTION
It should be a property type and not a device type. They both map to `0` so there is functionally no code changes, but at least strict type checking will work properly now and not error out.